### PR TITLE
first draft of training DT classifier on the wine dataset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,9 +81,9 @@ hugo/notebooks/%.md:
 
 hugo/content/%.md: hugo/notebooks/%.md
 	mkdir -p '$(dir $@)'
-	# $< == first prerequisite
-	awk -f ./hugo/notebooks/fix_md.awk '$<' > '$@'
-	cp '$(patsubst %.md,%_files,$<)'/* '$(dir $@)'
+	awk --lint=fatal -f ./hugo/notebooks/fix_md.awk '$<' > '$@'
+	$(eval supporting_files = $(wildcard $(patsubst %.md,%_files,$<)/*.*))
+	if test -n "$(supporting_files)"; then cp -v $(supporting_files) $(dir $@); fi
 
 # xargs trims whitespace from the hostname below
 .PHONY: serve-hugo
@@ -154,7 +154,7 @@ mocks: mockery
 # The awk command removes all graph edge definitions that don't include dud
 depgraph.png:
 	godepgraph -nostdlib . \
-		| awk '/^[^"]/ || /dud/ {print;}' \
+		| awk '/^[^"]/ || /dud/ {print}' \
 		| dot -Tpng -o $@
 
 %mb_random.bin:

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ docker: docker-image
 # Run any rule in this Makefile in the development Docker image.
 docker-%: docker-image
 	docker run \
+		--pull \
 		--rm \
 		-p 8888:8888 \
 		-v $(base_dir):/dud \

--- a/hugo/notebooks/fix_md.awk
+++ b/hugo/notebooks/fix_md.awk
@@ -10,10 +10,6 @@ BEGIN {
     sub(/[ \t\r]+$/, "")
 }
 
-/%%bash/ || /%%writefile/ {
-    next
-}
-
 /\w+_files\// {
     sub(/\w+_files\//, "../")
 }
@@ -55,12 +51,24 @@ BEGIN {
         # add the starting fence back.
         if (/^!/) {
             inBash = 1
-            inPython = 0
             sub(/^!/, "$ ", $0)
         } else {
             print inPython
         }
+        # Stop processing after the first line.
+        inPython = 0
     }
+}
+
+/%%bash/ { next }
+
+/%%writefile/ {
+    # Print the file name as a Python/shell comment at the top of the block.
+    print "# " $2
+    next
+}
+
+{
     if (inBash) {
         print "    "$0
     } else {

--- a/hugo/notebooks/getting_started/wine.ipynb
+++ b/hugo/notebooks/getting_started/wine.ipynb
@@ -1,0 +1,650 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training a Decision Tree Classifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide_input",
+     "hide_output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.makedirs('/tmp/wine', exist_ok=True)\n",
+    "os.chdir('/tmp/wine')\n",
+    "!sudo pacman -S wget --noconfirm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial we will use sklearn to train and validate a simple wine classifier using the [wine quality data set](https://archive.ics.uci.edu/ml/datasets/wine+quality). We will use `dud` to track the data and version the model weights."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Environment Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will first need to install `dud` which requires `go` to be in your PATH. The preferred method to install `dud` right now is to clone the repo and run `make install`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/kevin-hanselman/dud"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cd dud && make install && cd ../"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can verify that `dud` installed correctly by outputting the version."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will be using python and the sklearn and pandas packages to train our classifier. To manage python packages, we recommend that you first install a python virtual environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python -m venv .env\n",
+    "!source .env/bin/activate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then install the python packages we need."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide_output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!pip install scikit-learn pandas --user"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have `dud` installed and all of our python packages installed, let's make a new directory for our work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir wine_classifier && cd wine_classifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide_input",
+     "hide_output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "os.chdir('wine_classifier')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before we add any data, let's initialize a `dud` repo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud init"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This creates a `.dud` folder in the current folder and populates it with some config files that have sensible defaults. A `.dud/cache` folder is also created, but it's empty for now."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's verify that the above is true."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!tree .dud"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we're ready to add some data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will be using the \"Wine Quality Data Set\" from the UCI Machine Learning Repository, which we can download easily with `wget`. If you're unfamiliar with `wget`, all you need to know is that this command downloads a couple CSVs and saves them in the data folder. The command is shown below.\n",
+    "\n",
+    "    wget -q -r -np -nd -A csv https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/ -P data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can first make the `data` directory where we will download the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir data/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then create a `dud` stage to run the above command for us. A group of files or directories are known to dud as \"artifacts\". A stage is just a collection or an _operation_ on a collection of artifacts. A stage can be defined by a YAML file, and can be tracked with source control."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`dud` provides an easy way to generate stages, although stages can always be created and edited manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud stage gen"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A `-o` flag indicates that the stage will generate an artifact. We want to tell `dud` that our command will generate the `data` directory so that it knows to track it as an artifact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud stage gen -o data/"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also want to tell `dud` _how_ the artifact is generated. We can use the wget command from above. We use also use `--` which in bash means to stop parsing flags. This is needed so that `dud` doesn't try and parse the `wget` flags!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud stage gen -o data/ -- wget -q -r -np -nd -A csv https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/ -P data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It looks like this has all of the information we need! However, we haven't actually saved the output stage to a file yet. We can use \">\" to redirect `dud`'s autogenerated stage to a YAML file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud stage gen -o data/ -- wget -q -r -np -nd -A csv https://archive.ics.uci.edu/ml/machine-learning-databases/wine-quality/ -P data > get_data.yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we add a stage to `dud`, we're just letting `dud` know that a stage exists. This is kept track in an index file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat .dud/index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's tell `dud` to track that stage and check the index file and the status."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud stage add get_data.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!cat .dud/index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the stage hasn't been checksummed, but that `dud` is aware of the data artifact and knows that it is uncommitted. In fact, it is a design decision for `dud` to wait to commit until you tell it to. This is because the commit operation is one of the most costly operations since it involves lots of hashing. Let's fix that by running the stage and committing the output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud run get_data.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud commit get_data.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Excellent! Remember how the cache was empty before? You'll find that after the commit, the cache is no longer empty."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!tree .dud"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Those content-addressed files in the cache corespond to the data in the `data` folder. By default, `dud` symlinks the files in the working directory to point to the files in the cache."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The files in the cache are important because that's where the real copy of the file lives. `dud` tries to protect you from monkeying around with those cache files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls -l .dud/cache/3f/89718d7db7e8983db992bbe63b63c912b510aa279eef55fd6927f98a4a72f5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see that the this cache file has file permissions \"-r--r--r--\" which means that the file has read-only permissions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`dud` also tries to protect us from mishaps in our working directory. What if, through some freak accident, we delete our `data` folder? Since we committed, `dud` has us covered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -r data/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "No worries! We can simply recover the folder back to the working directory with a `dud checkout`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud checkout get_data.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As another protection, `dud` will refuse to run as root."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!sudo dud status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Training a Decision Tree Classifier"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's an example of a quick script to train a decision tree using scikit-learn on the wine dataset which saves the output model to a pickle file. Save this as train.py."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "hide_output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile train.py\n",
+    "import pickle\n",
+    "\n",
+    "import pandas as pd\n",
+    "from sklearn import tree\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "\n",
+    "red_wine =  pd.read_csv('data/winequality-red.csv', sep=';')\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(\n",
+    "    red_wine[['sulphates', 'alcohol']],\n",
+    "    red_wine['quality'],\n",
+    "    test_size=0.25,\n",
+    "    random_state=0)\n",
+    "\n",
+    "clf = tree.DecisionTreeClassifier().fit(X_train, y_train)\n",
+    "\n",
+    "print(f'Training Accuracy {round(accuracy_score(y_train, clf.predict(X_train)) * 100, 2)}%')\n",
+    "print(f'Testing Accuracy {round(accuracy_score(y_test, clf.predict(X_test)) * 100, 2)}%')\n",
+    "\n",
+    "with open('dt.pkl', 'wb') as f:\n",
+    "    pickle.dump(clf, f)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's use the same technique as our `get_data.yaml` stage, but use the `-d` flag to tell `dud` that the `data/` and `train.py` are dependencies of the this stage. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud stage gen -d data/ -d train.py -o dt.pkl python train.py > train.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud stage add train.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud st"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then train the model with `dud` run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud run train.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud st"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, we can commit whenever we're ready."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dud commit"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
My notes from our call:
- [x] modify installation instruction to include `make install` for versioning (until releases are on github)
- [x] introduce the `wget` command not as a shell command (might be confusing and looks like we're running it twice)
- [ ] verify that we describe the outputs of CLI blocks
- [x] change `| tee` to `>` where appropriate
- [x] show / introduce the index file when you add a stage
- [x] show the symbolic link pointing from the working directory to the cache (try to delete something in the cache?)
- [x] make train.py a dependency on the train stage
- [x] describe what the shell command `--` is doing

We also talked about breaking this single tutorial into a three part tutorial which talks about the principle goals of storing, versioning, and reproducing large files.

1. Overview / storing & versioning (the `dud` command, commit, checkout)
2. Reproducing (pipelining stages)
3. How remotes work (not covered in the current PR)