### PR TITLE
delete source file before linking, after commit

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,7 +1,6 @@
 name: build
 on:
   push:
-  pull_request:
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,8 @@ serve-hugo:
 		--baseUrl $(shell hostname -i | xargs)/dud/
 # xargs trims whitespace from the hostname
 
-.PHONY: %-test-cov
-%-test-cov: %-test.coverage
+.PHONY: coverage
+coverage: test.coverage
 	go tool cover -html=$<
 
 test.coverage:

--- a/src/cache/commit_test.go
+++ b/src/cache/commit_test.go
@@ -22,7 +22,7 @@ func TestFileCommitIntegration(t *testing.T) {
 
 	allStrategies := []strategy.CheckoutStrategy{strategy.LinkStrategy, strategy.CopyStrategy}
 
-	t.Run("happy path", func(t *testing.T) {
+	happyPath := func(t *testing.T) {
 		for _, strat := range allStrategies {
 			in := testInput{
 				Status: artifact.ArtifactWithStatus{
@@ -52,7 +52,9 @@ func TestFileCommitIntegration(t *testing.T) {
 				testCommitIntegration(in, out, t)
 			})
 		}
-	})
+	}
+
+	t.Run("happy path", happyPath)
 
 	t.Run("already up-to-date", func(t *testing.T) {
 		for _, strat := range allStrategies {
@@ -157,6 +159,17 @@ func TestFileCommitIntegration(t *testing.T) {
 				testCommitIntegration(in, out, t)
 			})
 		}
+	})
+
+	t.Run("fallback to copying files", func(t *testing.T) {
+		canRenameFileBetweenDirsOrig := canRenameFileBetweenDirs
+		canRenameFileBetweenDirs = func(_, _ string) (bool, error) {
+			return false, nil
+		}
+		defer func() {
+			canRenameFileBetweenDirs = canRenameFileBetweenDirsOrig
+		}()
+		happyPath(t)
 	})
 }
 


### PR DESCRIPTION
After commit, if we were forced to copy (instead of rename), we need to
delete the source file for the symlink to work.