### PR TITLE
misc: update website action

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -34,7 +34,8 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website
           publish_branch: gh-pages
-          force_orphan: true  # Limit to one commit in the published branch.
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
 
   goreleaser:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Removed 'force_orphan: true' from actions-gh-pages to enable reverting bad commits.