### PR TITLE
Document that stages w/o input are always considered out-of-date / are always rerun.

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -26,6 +26,7 @@ For each stage passed in, run executes a stage's command if it is out-of-date.
 If no stage files are passed in, run will act on all stages in the index. By
 default, run will act recursively on all stages upstream of the given stage,
 and thus run will execute a stage's command if any upstream stages are
+out-of-date. Notice that stages without an input are always considered
 out-of-date.`,
 	Run: func(cmd *cobra.Command, paths []string) {
 		rootDir, ch, idx, err := prepare(paths)


### PR DESCRIPTION
It was not clear to me from the docs that stages without an input stage are always rerun, thus invalidating any downstream stages.
I just spent half an hour debugging this, and haven't seen this documented clearly. Instead I found it here in the code:
https://github.com/kevin-hanselman/dud/blob/1b99eff4946977c4774cfabc56de2a3f9fbfe2cb/src/index/run.go#L55-L58

I think it would be good do document it in the `dud run` docstring, as proposed in this PR.